### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/nanocurrency-types/src/lib.rs
+++ b/nanocurrency-types/src/lib.rs
@@ -337,7 +337,7 @@ impl FromStr for Account {
         let mut matches = false;
         hasher.variable_result(move |checksum_calc| {
             matches = checksum_given
-                .into_iter()
+                .iter()
                 .rev()
                 .eq(checksum_calc.into_iter());
         });


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.